### PR TITLE
Add POCT EQA pre-submission analysis app

### DIFF
--- a/poct-eqa-precheck/.gitignore
+++ b/poct-eqa-precheck/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/poct-eqa-precheck/README.md
+++ b/poct-eqa-precheck/README.md
@@ -1,0 +1,26 @@
+# POCT EQA Pre-Submission Analysis Platform
+
+A lightweight, browser-based tool for analysing External Quality Assessment (EQA) results before submitting to providers. Upload CSV or Excel files to calculate statistics, view trend charts and export PDF/CSV reports.
+
+## Setup
+
+```bash
+npm install
+npm run dev
+```
+
+Build for deployment (e.g. Netlify):
+
+```bash
+npm run build
+```
+
+## File Format
+
+The uploaded file should contain the following columns:
+
+```
+device_id,analyte,test_date,measured_value,target_value
+```
+
+A sample template is available in `public/template.csv`.

--- a/poct-eqa-precheck/index.html
+++ b/poct-eqa-precheck/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>POCT EQA Pre-Submission Analysis</title>
+  </head>
+  <body class="bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/poct-eqa-precheck/package.json
+++ b/poct-eqa-precheck/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "poct-eqa-precheck",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-chartjs-2": "^5.2.0",
+    "chart.js": "^4.4.0",
+    "papaparse": "^5.3.2",
+    "xlsx": "^0.18.5",
+    "jspdf": "^2.5.1",
+    "html2canvas": "^1.4.1"
+  },
+  "devDependencies": {
+    "vite": "^4.5.0",
+    "@vitejs/plugin-react": "^3.1.0",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0"
+  }
+}

--- a/poct-eqa-precheck/postcss.config.js
+++ b/poct-eqa-precheck/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/poct-eqa-precheck/public/template.csv
+++ b/poct-eqa-precheck/public/template.csv
@@ -1,0 +1,4 @@
+device_id,analyte,test_date,measured_value,target_value
+Device A,Glucose,01/06/2025,5.6,5.5
+Device B,Glucose,01/06/2025,6.2,5.5
+Device C,Glucose,01/06/2025,4.9,5.5

--- a/poct-eqa-precheck/src/components/ChartsPanel.jsx
+++ b/poct-eqa-precheck/src/components/ChartsPanel.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Line, Scatter } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend } from 'chart.js';
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+export default function ChartsPanel({ data }) {
+  const dates = data.map(r => r.test_date);
+  const measured = data.map(r => r.measured_value);
+  const target = data.map(r => r.target_value);
+  const altmanData = data.map(r => ({ x: (r.measured_value + r.target_value) / 2, y: r.measured_value - r.target_value }));
+
+  const lineData = {
+    labels: dates,
+    datasets: [
+      { label: 'Measured', data: measured, borderColor: 'blue' },
+      { label: 'Target', data: target, borderColor: 'green' },
+    ],
+  };
+
+  const altmanConfig = {
+    datasets: [
+      {
+        label: 'Altman-Bland',
+        data: altmanData,
+        borderColor: 'red',
+        showLine: false,
+      },
+    ],
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="font-bold mb-2">Trend</h3>
+        <Line data={lineData} />
+      </div>
+      <div>
+        <h3 className="font-bold mb-2">Altman-Bland Plot</h3>
+        <Scatter data={altmanConfig} />
+      </div>
+    </div>
+  );
+}

--- a/poct-eqa-precheck/src/components/ExportPanel.jsx
+++ b/poct-eqa-precheck/src/components/ExportPanel.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { exportCSV, exportPDF } from '../utils/exporters.js';
+
+export default function ExportPanel({ data, stats }) {
+  return (
+    <div className="space-x-4">
+      <button
+        className="bg-blue-600 text-white px-4 py-2 rounded"
+        onClick={() => exportCSV(data)}
+      >
+        Export as CSV
+      </button>
+      <button
+        className="bg-blue-600 text-white px-4 py-2 rounded"
+        onClick={() => exportPDF(data, stats)}
+      >
+        Export PDF Report
+      </button>
+    </div>
+  );
+}

--- a/poct-eqa-precheck/src/components/StatsTable.jsx
+++ b/poct-eqa-precheck/src/components/StatsTable.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { groupByDevice, deviceStats } from '../utils/stats.js';
+
+export default function StatsTable({ data }) {
+  const grouped = groupByDevice(data);
+  const rows = Object.keys(grouped).map((device) => ({
+    device,
+    ...deviceStats(grouped[device]),
+  }));
+
+  const color = (cv) => {
+    if (cv < 5) return 'bg-green-100';
+    if (cv < 10) return 'bg-yellow-100';
+    return 'bg-red-100';
+  };
+
+  return (
+    <table className="min-w-full text-sm">
+      <thead>
+        <tr>
+          <th className="border px-2">Device</th>
+          <th className="border px-2">Mean</th>
+          <th className="border px-2">SD</th>
+          <th className="border px-2">CV%</th>
+          <th className="border px-2"># Tests</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r) => (
+          <tr key={r.device} className={color(r.cv)}>
+            <td className="border px-2">{r.device}</td>
+            <td className="border px-2">{r.mean.toFixed(2)}</td>
+            <td className="border px-2">{r.sd.toFixed(2)}</td>
+            <td className="border px-2">{r.cv.toFixed(2)}</td>
+            <td className="border px-2">{r.count}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/poct-eqa-precheck/src/components/SummaryPanel.jsx
+++ b/poct-eqa-precheck/src/components/SummaryPanel.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function SummaryPanel({ stats }) {
+  const warn = stats.cv > 5;
+  return (
+    <div className={`p-4 rounded shadow ${warn ? 'bg-yellow-100' : 'bg-green-100'}`}> 
+      <p><strong>Analyte:</strong> {stats.analyte}</p>
+      <p><strong>Devices:</strong> {stats.devices}</p>
+      <p><strong>Mean:</strong> {stats.mean.toFixed(2)}</p>
+      <p><strong>SD:</strong> {stats.sd.toFixed(2)}</p>
+      <p><strong>CV%:</strong> {stats.cv.toFixed(2)}</p>
+      {warn && <p className="text-red-600">Warning: CV% &gt; 5%</p>}
+    </div>
+  );
+}

--- a/poct-eqa-precheck/src/components/UploadArea.jsx
+++ b/poct-eqa-precheck/src/components/UploadArea.jsx
@@ -1,0 +1,33 @@
+import React, { useRef } from 'react';
+
+export default function UploadArea({ onFile }) {
+  const inputRef = useRef();
+
+  const handleFiles = (files) => {
+    if (files.length) {
+      onFile(files[0]);
+    }
+  };
+
+  return (
+    <div className="border-2 border-dashed p-6 text-center rounded">
+      <input
+        type="file"
+        accept=".csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel"
+        className="hidden"
+        ref={inputRef}
+        onChange={(e) => handleFiles(e.target.files)}
+      />
+      <p className="mb-2">Drag and drop or select a CSV/XLSX file</p>
+      <button
+        className="bg-blue-600 text-white px-4 py-2 rounded"
+        onClick={() => inputRef.current.click()}
+      >
+        Select File
+      </button>
+      <a href="/template.csv" className="ml-4 text-blue-600 underline">
+        Download Template
+      </a>
+    </div>
+  );
+}

--- a/poct-eqa-precheck/src/index.css
+++ b/poct-eqa-precheck/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/poct-eqa-precheck/src/main.jsx
+++ b/poct-eqa-precheck/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './pages/App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/poct-eqa-precheck/src/pages/App.jsx
+++ b/poct-eqa-precheck/src/pages/App.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Home from './Home.jsx';
+import Dashboard from './Dashboard.jsx';
+
+export default function App() {
+  const [page, setPage] = React.useState('home');
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <nav className="bg-blue-600 text-white p-4 flex justify-between">
+        <div className="font-bold">POCTIFY</div>
+        <div className="space-x-4">
+          <button onClick={() => setPage('home')}>Home</button>
+          <button onClick={() => setPage('dashboard')}>Dashboard</button>
+        </div>
+      </nav>
+      <main className="flex-grow p-4">
+        {page === 'home' ? <Home onLaunch={() => setPage('dashboard')} /> : <Dashboard />}
+      </main>
+    </div>
+  );
+}

--- a/poct-eqa-precheck/src/pages/Dashboard.jsx
+++ b/poct-eqa-precheck/src/pages/Dashboard.jsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import UploadArea from '../components/UploadArea.jsx';
+import SummaryPanel from '../components/SummaryPanel.jsx';
+import ChartsPanel from '../components/ChartsPanel.jsx';
+import StatsTable from '../components/StatsTable.jsx';
+import ExportPanel from '../components/ExportPanel.jsx';
+import { parseFile } from '../utils/parseFile.js';
+import { computeStats } from '../utils/stats.js';
+
+export default function Dashboard() {
+  const [data, setData] = useState([]);
+  const [stats, setStats] = useState({ devices: 0, mean: 0, sd: 0, cv: 0, analyte: '' });
+
+  const handleFile = async (file) => {
+    const rows = await parseFile(file);
+    setData(rows);
+    setStats(computeStats(rows));
+  };
+
+  return (
+    <div className="space-y-6">
+      <UploadArea onFile={handleFile} />
+      {data.length > 0 && (
+        <>
+          <SummaryPanel stats={stats} />
+          <ChartsPanel data={data} />
+          <StatsTable data={data} />
+          <ExportPanel data={data} stats={stats} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/poct-eqa-precheck/src/pages/Home.jsx
+++ b/poct-eqa-precheck/src/pages/Home.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function Home({ onLaunch }) {
+  return (
+    <div className="text-center space-y-4 mt-20">
+      <h1 className="text-4xl font-bold">Get Ahead of EQA Failures.</h1>
+      <p className="text-lg">Upload your EQA results and analyse before submitting.</p>
+      <button
+        className="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700"
+        onClick={onLaunch}
+      >
+        Launch Dashboard
+      </button>
+    </div>
+  );
+}

--- a/poct-eqa-precheck/src/utils/exporters.js
+++ b/poct-eqa-precheck/src/utils/exporters.js
@@ -1,0 +1,23 @@
+import { utils, writeFile } from 'xlsx';
+import jsPDF from 'jspdf';
+import html2canvas from 'html2canvas';
+
+export function exportCSV(rows) {
+  const ws = utils.json_to_sheet(rows);
+  const wb = utils.book_new();
+  utils.book_append_sheet(wb, ws, 'Results');
+  writeFile(wb, 'eqa_results.xlsx');
+}
+
+export async function exportPDF(rows, stats) {
+  const doc = new jsPDF();
+  doc.text('EQA Report', 10, 10);
+  doc.text(`Generated: ${new Date().toLocaleDateString()}`, 10, 20);
+  const table = document.querySelector('table');
+  if (table) {
+    const canvas = await html2canvas(table);
+    const imgData = canvas.toDataURL('image/png');
+    doc.addImage(imgData, 'PNG', 10, 30, 180, 100);
+  }
+  doc.save('eqa_report.pdf');
+}

--- a/poct-eqa-precheck/src/utils/parseFile.js
+++ b/poct-eqa-precheck/src/utils/parseFile.js
@@ -1,0 +1,37 @@
+import Papa from 'papaparse';
+import * as XLSX from 'xlsx';
+
+export async function parseFile(file) {
+  const ext = file.name.split('.').pop().toLowerCase();
+  if (ext === 'csv') {
+    return new Promise((resolve, reject) => {
+      Papa.parse(file, {
+        header: true,
+        dynamicTyping: true,
+        skipEmptyLines: true,
+        complete: (results) => resolve(cleanRows(results.data)),
+        error: reject,
+      });
+    });
+  }
+  if (ext === 'xlsx') {
+    const data = await file.arrayBuffer();
+    const wb = XLSX.read(data, { type: 'array' });
+    const ws = wb.Sheets[wb.SheetNames[0]];
+    const json = XLSX.utils.sheet_to_json(ws);
+    return cleanRows(json);
+  }
+  throw new Error('Unsupported file type');
+}
+
+function cleanRows(rows) {
+  return rows
+    .map(r => ({
+      device_id: r.device_id || r.Device || r.device || '',
+      analyte: r.analyte,
+      test_date: r.test_date || r.date,
+      measured_value: parseFloat(r.measured_value || r.measured || r.value),
+      target_value: parseFloat(r.target_value || r.target),
+    }))
+    .filter(r => r.device_id && !isNaN(r.measured_value) && !isNaN(r.target_value));
+}

--- a/poct-eqa-precheck/src/utils/stats.js
+++ b/poct-eqa-precheck/src/utils/stats.js
@@ -1,0 +1,33 @@
+export function groupByDevice(rows) {
+  return rows.reduce((acc, row) => {
+    if (!acc[row.device_id]) acc[row.device_id] = [];
+    acc[row.device_id].push(row);
+    return acc;
+  }, {});
+}
+
+export function deviceStats(rows) {
+  const values = rows.map(r => r.measured_value);
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const variance = values.reduce((a, b) => a + Math.pow(b - mean, 2), 0) / values.length;
+  const sd = Math.sqrt(variance);
+  const cv = (sd / mean) * 100;
+  return { mean, sd, cv, count: values.length };
+}
+
+export function computeStats(rows) {
+  if (!rows.length) return { devices: 0, mean: 0, sd: 0, cv: 0, analyte: '' };
+  const grouped = groupByDevice(rows);
+  const allValues = rows.map(r => r.measured_value);
+  const mean = allValues.reduce((a, b) => a + b, 0) / allValues.length;
+  const variance = allValues.reduce((a, b) => a + Math.pow(b - mean, 2), 0) / allValues.length;
+  const sd = Math.sqrt(variance);
+  const cv = (sd / mean) * 100;
+  return {
+    devices: Object.keys(grouped).length,
+    mean,
+    sd,
+    cv,
+    analyte: rows[0].analyte,
+  };
+}

--- a/poct-eqa-precheck/tailwind.config.js
+++ b/poct-eqa-precheck/tailwind.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx,ts,tsx}',
+  ],
+  darkMode: 'class',
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/poct-eqa-precheck/vite.config.js
+++ b/poct-eqa-precheck/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add new React/Vite app for EQA data pre-submission checks
- include upload, stats, charting, export and summary components
- sample data template in `public/template.csv`
- Tailwind CSS and configuration for styling

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` from repo root *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6864477779e083228286c1d63d970a45